### PR TITLE
Revert "Bump pillow from 9.4.0 to 10.0.1 in /EXE201"

### DIFF
--- a/EXE201/requirements.txt
+++ b/EXE201/requirements.txt
@@ -4,5 +4,5 @@ Flask_Login==0.6.2
 flask_sqlalchemy==3.0.3
 Flask_WTF==1.0.1
 WTForms==2.3.3
-Pillow==10.0.1
+Pillow==9.4.0
 email_validator==1.2.1


### PR DESCRIPTION
Reverts Luckydog381/EXE201#1
This pull request includes a small change to the `EXE201/requirements.txt` file. The change downgrades the version of the `Pillow` library to ensure compatibility with other dependencies.

* [`EXE201/requirements.txt`](diffhunk://#diff-d163ab8e2766790cf0412a5d8e2ef450fc7c6364ebf86564111a9a74a7646328L7-R7): Downgraded `Pillow` from version 10.0.1 to 9.4.0.